### PR TITLE
Feat: addition of mock classes for url session and url session data task

### DIFF
--- a/BittrexTracker.xcodeproj/project.pbxproj
+++ b/BittrexTracker.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9C85C05421F759C100E9259D /* URLSessionMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C85C05321F759C100E9259D /* URLSessionMock.swift */; };
+		9C85C05621F75D4D00E9259D /* URLSessionDataTaskMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C85C05521F75D4D00E9259D /* URLSessionDataTaskMock.swift */; };
 		9C8F8FB421F67E120034DF4A /* BittrexTracker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C8F8FAA21F67E120034DF4A /* BittrexTracker.framework */; };
 		9C8F8FB921F67E120034DF4A /* BittrexTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8F8FB821F67E120034DF4A /* BittrexTrackerTests.swift */; };
 		9C8F8FBB21F67E120034DF4A /* BittrexTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C8F8FAD21F67E120034DF4A /* BittrexTracker.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -33,6 +35,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		9C85C05321F759C100E9259D /* URLSessionMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionMock.swift; sourceTree = "<group>"; };
+		9C85C05521F75D4D00E9259D /* URLSessionDataTaskMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionDataTaskMock.swift; sourceTree = "<group>"; };
 		9C8F8FAA21F67E120034DF4A /* BittrexTracker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BittrexTracker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9C8F8FAD21F67E120034DF4A /* BittrexTracker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BittrexTracker.h; sourceTree = "<group>"; };
 		9C8F8FAE21F67E120034DF4A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -104,6 +108,8 @@
 			children = (
 				9C8F8FB821F67E120034DF4A /* BittrexTrackerTests.swift */,
 				9C8F8FBA21F67E120034DF4A /* Info.plist */,
+				9C85C05321F759C100E9259D /* URLSessionMock.swift */,
+				9C85C05521F75D4D00E9259D /* URLSessionDataTaskMock.swift */,
 			);
 			path = BittrexTrackerTests;
 			sourceTree = "<group>";
@@ -258,7 +264,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9C85C05421F759C100E9259D /* URLSessionMock.swift in Sources */,
 				9C8F8FB921F67E120034DF4A /* BittrexTrackerTests.swift in Sources */,
+				9C85C05621F75D4D00E9259D /* URLSessionDataTaskMock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BittrexTracker/Collector/BittrexCollector.swift
+++ b/BittrexTracker/Collector/BittrexCollector.swift
@@ -67,7 +67,6 @@ final class BittrexCollector {
     final func getMarkets(completion: @escaping ((MarketsRequest) -> Void)) {
         let url = URL(string: baseURL+apiVersion+marketsURL)
         let task = session.dataTask(with: url!) { (data, response, error) in
-            print(data)
             if error != nil {
                 print("Error encountered when getting markets: \(String(describing: error))")
             } else {

--- a/BittrexTrackerTests/URLSessionDataTaskMock.swift
+++ b/BittrexTrackerTests/URLSessionDataTaskMock.swift
@@ -1,0 +1,21 @@
+//
+//  URLSessionDataTaskMock.swift
+//  BittrexTrackerTests
+//
+//  Created by Matthew  Dovey on 22/01/2019.
+//  Copyright © 2019 Matthew Dovey. All rights reserved.
+//
+
+import Foundation
+
+class URLSessionDataTaskMock : URLSessionDataTask {
+    private let closure: () -> Void
+    
+    init(closure: @escaping () -> Void) {
+        self.closure = closure
+    }
+    
+    override func resume() {
+        closure()
+    }
+}

--- a/BittrexTrackerTests/URLSessionMock.swift
+++ b/BittrexTrackerTests/URLSessionMock.swift
@@ -1,0 +1,25 @@
+//
+//  URLSessionMock.swift
+//  BittrexTrackerTests
+//
+//  Created by Matthew  Dovey on 22/01/2019.
+//  Copyright © 2019 Matthew Dovey. All rights reserved.
+//
+
+import Foundation
+
+class URLSessionMock : URLSession {
+    typealias CompletionHandler = (Data?, URLResponse?, Error?) -> Void
+    
+    var data: Data?
+    var error: Error?
+    
+    override func dataTask(with url: URL, completionHandler: @escaping CompletionHandler) -> URLSessionDataTask {
+        let data = self.data
+        let error = self.error
+        
+        return URLSessionDataTaskMock {
+            completionHandler(data, nil, error)
+        }
+    }
+}


### PR DESCRIPTION
This PR adds mock classes for URLSession and URLSessionDataTask so that the BittrexCollector can be unit tested through mocking.